### PR TITLE
addEntityToLocation() method fix

### DIFF
--- a/src/grid.py
+++ b/src/grid.py
@@ -81,7 +81,7 @@ class Grid(object):
     
     # Adds an entity to a specified location in this grid.
     def addEntityToLocation(self, entity: Entity, location):
-        entity.setGridID(self.getID)
+        entity.setGridID(self.getID())
         
         self.locations[location.getID()].addEntity(entity)
     


### PR DESCRIPTION
The entity's gridID was being set to a method rather than actually calling the method to get a value. This has been fixed.

closes #17 