### PR TITLE
Fixed reference error in Grid class

### DIFF
--- a/src/grid.py
+++ b/src/grid.py
@@ -95,7 +95,7 @@ class Grid(object):
     
     # Checks if an entity is present in this grid.
     def isEntityPresent(self, entity: Entity):
-        for locationId in self.grid.getLocations():
+        for locationId in self.getLocations():
             location = self.locations[locationId]
             if location.isEntityPresent(entity):
                 return True

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -123,3 +123,16 @@ def test_getLocationByCoordinates_LargeGrid():
     assert retrievedLocation != None
     assert retrievedLocation.getX() == targetX
     assert retrievedLocation.getY() == targetY
+
+def test_isEntityPresent():
+    # prepare
+    grid = Grid(NORMAL_SIZE, NORMAL_SIZE)
+    entity = Entity("test")
+    location = grid.getRandomLocation()
+    grid.addEntityToLocation(entity, location)
+
+    # execute
+    isPresent = grid.isEntityPresent(entity)
+
+    # verify
+    assert isPresent == True


### PR DESCRIPTION
## Problem
The Grid class contains a reference to self.grid.getLocations(), but there is no instance variable named grid. As a result, calling the isEntityPresent() method causes an error.

## Solution
The reference has been corrected to self.getLocations(), which is a valid method in the Grid class.